### PR TITLE
[RFR] Discover projects in new KISS/<User>/<Project>/bin structure

### DIFF
--- a/src/ArchivesModel.cpp
+++ b/src/ArchivesModel.cpp
@@ -36,7 +36,7 @@ ArchivesModel::ArchivesModel(Device *device, QObject *parent)
 	
   QFileSystemWatcher *watcher = new QFileSystemWatcher(this);
   // TODO: hardcoded system path
-  watcher->addPath("/home/root/Documents/KISS/bin/");
+  watcher->addPath("/home/kipr/Documents/KISS/");
   //watcher->addPath(SystemPrefix::ref().rootManager()->archivesPath());
 	
   connect(watcher, SIGNAL(directoryChanged(QString)), SLOT(refresh()));
@@ -76,13 +76,19 @@ void ArchivesModel::archiveRemoved(const QString &name)
 
 void ArchivesModel::refresh()
 {
-	clear();
+  clear();
   // TODO: hardcoded system path
-  const QDir binDir("/home/root/Documents/KISS/bin/");
-  foreach(const QString &name, binDir.entryList(QDir::NoDot | QDir::NoDotDot | QDir::Dirs))
-    appendRow(new ArchiveItem(name));
-	/*foreach(const QString &name, SystemPrefix::ref().rootManager()->archives()
-      .entryList(QDir::NoDot | QDir::NoDotDot | QDir::Files)) {
-		appendRow(new ArchiveItem(name));
-	}*/
+  const QDir kissDir("/home/kipr/Documents/KISS/");
+
+  foreach(const QString &userName, kissDir.entryList(QDir::NoDot | QDir::NoDotDot | QDir::Dirs))
+  {
+    const QDir userDir("/home/kipr/Documents/KISS/" + userName);
+    foreach(const QString &projectName, userDir.entryList(QDir::NoDot | QDir::NoDotDot | QDir::Dirs))
+    {
+      const QString userAndProject = userName + "/" + projectName+ "/";
+      const QDir projDir(kissDir.absolutePath() +  "/" + userAndProject + "/");
+      const QDir binDir(projDir.absolutePath() + "/bin/");
+      if (binDir.exists("botball_user_program")) appendRow(new ArchiveItem(userAndProject));
+    }
+  }
 }

--- a/src/ArchivesModel.cpp
+++ b/src/ArchivesModel.cpp
@@ -36,7 +36,7 @@ ArchivesModel::ArchivesModel(Device *device, QObject *parent)
 	
   QFileSystemWatcher *watcher = new QFileSystemWatcher(this);
   // TODO: hardcoded system path
-  watcher->addPath("/home/kipr/Documents/KISS/");
+  watcher->addPath("/home/root/Documents/KISS/");
   //watcher->addPath(SystemPrefix::ref().rootManager()->archivesPath());
 	
   connect(watcher, SIGNAL(directoryChanged(QString)), SLOT(refresh()));

--- a/src/ArchivesModel.cpp
+++ b/src/ArchivesModel.cpp
@@ -78,11 +78,11 @@ void ArchivesModel::refresh()
 {
   clear();
   // TODO: hardcoded system path
-  const QDir kissDir("/home/kipr/Documents/KISS/");
+  const QDir kissDir("/home/root/Documents/KISS/");
 
   foreach(const QString &userName, kissDir.entryList(QDir::NoDot | QDir::NoDotDot | QDir::Dirs))
   {
-    const QDir userDir("/home/kipr/Documents/KISS/" + userName);
+    const QDir userDir("/home/root/Documents/KISS/" + userName);
     foreach(const QString &projectName, userDir.entryList(QDir::NoDot | QDir::NoDotDot | QDir::Dirs))
     {
       const QString userAndProject = userName + "/" + projectName+ "/";

--- a/src/ProgramsWidget.cpp
+++ b/src/ProgramsWidget.cpp
@@ -112,8 +112,9 @@ void ProgramsWidget::run()
 	}*/
   // TODO: hardcoded system path
   // Make sure binary exists for this project
-  const QDir projDir("/home/root/Documents/KISS/bin/" + name);
-  if(!projDir.exists("botball_user_program")) {
+  const QDir projDir("/home/kipr/Documents/KISS/" + name);
+  qDebug() << name;
+  if(!projDir.exists("bin/botball_user_program")) {
     QMessageBox::warning(this, tr("No Executable"), tr("No executable exists for the selected proejct."));
     return;
   }
@@ -146,7 +147,7 @@ void ProgramsWidget::run()
 	}*/
   
   ProgramWidget *programWidget = new ProgramWidget(Program::instance(), device());
-  const bool success = Program::instance()->start(projDir.filePath("botball_user_program"), QStringList());
+  const bool success = Program::instance()->start(projDir.filePath("bin/botball_user_program"), QStringList());
   
   if(success) RootController::ref().presentWidget(programWidget);
   else delete programWidget;

--- a/src/ProgramsWidget.cpp
+++ b/src/ProgramsWidget.cpp
@@ -112,7 +112,7 @@ void ProgramsWidget::run()
 	}*/
   // TODO: hardcoded system path
   // Make sure binary exists for this project
-  const QDir projDir("/home/kipr/Documents/KISS/" + name);
+  const QDir projDir("/home/root/Documents/KISS/" + name);
   qDebug() << name;
   if(!projDir.exists("bin/botball_user_program")) {
     QMessageBox::warning(this, tr("No Executable"), tr("No executable exists for the selected proejct."));


### PR DESCRIPTION
This change allows Botui to find projects created using the new directory structure from https://github.com/kipr/harrogate/pull/44

where executables are found at 

`/home/root/Documents/KISS/<User>/<Project>/bin/botball_user_program`

instead of

`/home/root/Documents/KISS/bin/<Project>/botball_user_program`
