### PR TITLE
[RFR] Using motor_power function since motor changed to mav

### DIFF
--- a/src/CombinedMotorWidget.cpp
+++ b/src/CombinedMotorWidget.cpp
@@ -84,7 +84,7 @@ void CombinedMotorWidget::pwmChanged(double pwm)
 	ui->fd->setEnabled(pwm < 99.5);
 	ui->bk->setEnabled(pwm > -99.5);
 	ui->pwmStop->setEnabled(qAbs(pwm) > 0.5);
-	motor(ui->motors->currentIndex(), pwm);
+	motor_power(ui->motors->currentIndex(), pwm);
 #ifdef A_KOVAN
 	publish();
 #endif


### PR DESCRIPTION
``motor()`` now does velocity control (https://github.com/kipr/libwallaby/pull/72), which meant our CombinedMotorWidget was using the incorrect drive method instead of PWM control.  

The mismatch also caused the motor to not go completely idle when the stop button was pressed... because it was using PID control to attempt a target velocity of 0, instead of setting a duty cycle of 0%. 