### PR TITLE
[RFR] Update dependencies in the Readme

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -7,9 +7,7 @@ The icons used throughout botui are from the [Silk icon set](http://www.famfamfa
 
 Requirements
 ============
-
-* libkar
-* pcompiler
+* pcompiler  (Use_qt4 branch: https://github.com/kipr/pcompiler/tree/use_Qt4)
 * CMake 2.6.0 or later
 * Qt 4.7.4 or later
 


### PR DESCRIPTION
We no longer rely on libkar.

Issues have been noted with Qt5. We use a branch of pcompiler which uses Qt4 instead.

We will not use pcompiler for much longer.