### PR TITLE
Set widget size to 480x242

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -10,7 +10,7 @@
 namespace botui
 {
 
-	const QString pathToKISS = "/home/root/Documents/KISS/";
+	const QString pathToKISS = "/home/kipr/Documents/KISS/";
 
 }
 

--- a/src/RootController.cpp
+++ b/src/RootController.cpp
@@ -100,8 +100,9 @@ bool RootController::isFullscreen() const
 
 void RootController::constrain(QWidget *widget)
 {
-	widget->setMinimumSize(320, 240);
-	widget->setMaximumSize(320, 240);
+	// 480x242 is the default Wallaby resolution
+	widget->setMinimumSize(480, 242);
+	widget->setMaximumSize(480, 242);
 }
 
 void RootController::present(QWidget *widget)


### PR DESCRIPTION
The Wallaby display resolution is 480x242, not 320x240 (the Link1 resolution). 