### PR TITLE
Fixed the blob labels menu, made it more intuitive

### DIFF
--- a/src/CameraLiveWidget.cpp
+++ b/src/CameraLiveWidget.cpp
@@ -41,9 +41,15 @@ CameraLiveWidget::CameraLiveWidget(Device *device, QWidget *parent)
   const SettingsProvider *const settingsProvider = device->settingsProvider();
   if(settingsProvider) {
     const bool showBbox = settingsProvider->value("bounding_box", true).toBool();
+    const bool blobLabels = settingsProvider->value("blob_labels", true).toBool();
     const int numLabels = settingsProvider->value("num_blob_labels", 0).toInt();
     ui->camera->setShowBbox(showBbox);
-    ui->camera->setNumBlobLabels(numLabels);
+    if(blobLabels){
+    	ui->camera->setNumBlobLabels(numLabels);
+	}
+	else{
+		ui->camera->setNumBlobLabels(0);
+	}  
   }
   
   ui->channelView->setModel(u_model);

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -6,6 +6,7 @@
 
 #define BOUNDING_BOX_KEY "bounding_box"
 #define NUM_BLOB_LABELS_KEY "num_blob_labels"
+#define BLOB_LABELS_KEY "blob_labels"
 
 CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent)
   : StandardWidget(device, parent)
@@ -18,9 +19,11 @@ CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent
   const SettingsProvider *const settingsProvider = device->settingsProvider();
   if(settingsProvider) {
     const bool bbox = settingsProvider->value(BOUNDING_BOX_KEY, true).toBool();
+    const bool blobLabels = settingsProvider->value(BLOB_LABELS_KEY, true).toBool();
     const int numLabels = settingsProvider->value(NUM_BLOB_LABELS_KEY, 0).toInt();
     
     ui->boundingBox->setChecked(bbox);
+    ui->blobLabels->setChecked(blobLabels);
     ui->numLabels->setValue(numLabels);
   }
   
@@ -31,6 +34,7 @@ CameraSettingsWidget::~CameraSettingsWidget()
   SettingsProvider *const settingsProvider = device()->settingsProvider();
   if(settingsProvider) {
     settingsProvider->setValue(BOUNDING_BOX_KEY, ui->boundingBox->isChecked());
+    settingsProvider->setValue(BLOB_LABELS_KEY, ui->blobLabels->isChecked());
     settingsProvider->setValue(NUM_BLOB_LABELS_KEY, ui->numLabels->value());
     settingsProvider->sync();
   }

--- a/ui/CameraSettingsWidget.ui
+++ b/ui/CameraSettingsWidget.ui
@@ -27,19 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="font">
-        <font>
-         <pointsize>33</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Show bounding boxes:</string>
-       </property>
-      </widget>
-     </item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1">
      <item>
       <widget class="QCheckBox" name="boundingBox">
        <property name="minimumSize">
@@ -54,7 +42,7 @@
         </font>
        </property>
        <property name="text">
-        <string/>
+        <string>Show Bounding Boxes?</string>
        </property>
        <property name="iconSize">
         <size>
@@ -67,6 +55,33 @@
     </layout>
    </item>
    <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="blobLabels">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>33</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Show Blob Labels?</string>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>18</width>
+       <height>18</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
      <item>
       <widget class="QLabel" name="label">
@@ -76,7 +91,7 @@
         </font>
        </property>
        <property name="text">
-        <string>Show blob labels:</string>
+        <string>Max Blob Labels:</string>
        </property>
       </widget>
      </item>
@@ -91,7 +106,10 @@
         <string> blob(s)</string>
        </property>
        <property name="prefix">
-        <string>First </string>
+        <string> </string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
        </property>
        <property name="maximum">
         <number>10</number>
@@ -99,21 +117,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QLabel" name="label_3">
-     <property name="font">
-      <font>
-       <pointsize>22</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Note: These settings only affect the camera view. Other programs will not be affected.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -127,6 +130,21 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Note: These settings only affect the camera view. Other programs, such as your code, will not be affected.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
There was an issue with ambiguity on the blob labels reported in issues.
This is a redesign to make the menu explain it better.

Now there is a separate checkbox for enabling blob labels, and the blob label spin-box starts at 1