### PR TITLE
Update and rename Readme.markdown to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,7 @@ Requirements
 ============
 * pcompiler  (Use_qt4 branch: https://github.com/kipr/pcompiler/tree/use_Qt4)
 * CMake 2.6.0 or later
-* Qt 4.7.4 or later
-
-Authors
-=======
-* Braden McDorman
-* Joshua Southerland
-* Nafis Zaman
-* Prithviraj Kadiyala
+* [Qt >= 4.7.4](https://www.qt.io/download-qt-installer)
 
 
 License


### PR DESCRIPTION
Added a link to where Qt can be downloaded from, when I locked a while back it was hard to find.
Since Github lists the contributors on the right in repo I just removed the names to clean up the read me, I assume the readme is going to start getting a bit longer.