### PR TITLE
Disable Turn on/off button

### DIFF
--- a/src/NetworkSettingsWidget.cpp
+++ b/src/NetworkSettingsWidget.cpp
@@ -88,18 +88,22 @@ void NetworkSettingsWidget::manage()
 
 void NetworkSettingsWidget::enableAP()
 {
+	/*
 	disableAPControlsTemporarily();
 	NetworkManager::ref().enableAP();
 	ui->turnOn->hide();
 	ui->turnOff->show();
+	*/
 }
 
 void NetworkSettingsWidget::disableAP()
 {
+	/*
 	disableAPControlsTemporarily();
 	NetworkManager::ref().disableAP();
 	ui->turnOn->show();
 	ui->turnOff->hide();
+	*/
 }
 
 void NetworkSettingsWidget::enableAPControls()


### PR DESCRIPTION
Customers keep going straight to the network menu and hitting the turn on button to try and fix their wifi, which only causes it to turn off because they didn't wait for the wifi to turn on.

I think this should be disabled because I have never seen someone need to use this and it only seems to cause tech support problems.

I will leave this up for public comment until 06/15/2021