### PR TITLE
Fixing Factory Page

### DIFF
--- a/include/botui/CameraSettingsWidget.h
+++ b/include/botui/CameraSettingsWidget.h
@@ -14,7 +14,10 @@ Q_OBJECT
 public:
   CameraSettingsWidget(Device *device, QWidget *const parent = 0);
   ~CameraSettingsWidget();
-  
+
+public slots:
+        void minus();
+        void plus();
 private:
   Ui::CameraSettingsWidget *ui;
 };

--- a/include/botui/FactoryWidget.h
+++ b/include/botui/FactoryWidget.h
@@ -24,8 +24,8 @@ public slots:
         void experimental();
 	
 private:
-	Device *m_device;
-	NumpadDialog *m_serialNumpad;
+        //Device *m_device;
+        //NumpadDialog *m_serialNumpad;
 	
 	Ui::FactoryWidget *ui;
 };

--- a/include/botui/FactoryWidget.h
+++ b/include/botui/FactoryWidget.h
@@ -8,9 +8,6 @@ namespace Ui
 	class FactoryWidget;
 }
 
-class NumpadDialog;
-class Device;
-
 class FactoryWidget : public StandardWidget
 {
 Q_OBJECT
@@ -24,8 +21,6 @@ public slots:
         void experimental();
 	
 private:
-        //Device *m_device;
-        //NumpadDialog *m_serialNumpad;
 	
 	Ui::FactoryWidget *ui;
 };

--- a/include/botui/FactoryWidget.h
+++ b/include/botui/FactoryWidget.h
@@ -1,7 +1,7 @@
 #ifndef _FACTORYWIDGET_H_
 #define _FACTORYWIDGET_H_
 
-#include <QWidget>
+#include "StandardWidget.h"
 
 namespace Ui
 {

--- a/include/botui/FactoryWidget.h
+++ b/include/botui/FactoryWidget.h
@@ -11,7 +11,7 @@ namespace Ui
 class NumpadDialog;
 class Device;
 
-class FactoryWidget : public QWidget
+class FactoryWidget : public StandardWidget
 {
 Q_OBJECT
 public:

--- a/include/botui/FactoryWidget.h
+++ b/include/botui/FactoryWidget.h
@@ -5,24 +5,25 @@
 
 namespace Ui
 {
-	class FactoryWidget;
+        class FactoryWidget;
 }
 
 class FactoryWidget : public StandardWidget
 {
 Q_OBJECT
 public:
-	FactoryWidget(Device *device, QWidget *parent = 0);
-	~FactoryWidget();
-	
+        FactoryWidget(Device *device, QWidget *parent = 0);
+        ~FactoryWidget();
+
 public slots:
-	void confirm();
+        void confirm();
         void reflash();
         void experimental();
-	
+
+
 private:
-	
-	Ui::FactoryWidget *ui;
+        Ui::FactoryWidget *ui;
 };
+
 
 #endif

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -8,6 +8,7 @@
 #define NUM_BLOB_LABELS_KEY "num_blob_labels"
 #define BLOB_LABELS_KEY "blob_labels"
 
+
 CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent)
   : StandardWidget(device, parent)
   , ui(new Ui::CameraSettingsWidget)
@@ -27,7 +28,7 @@ CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent
     
     ui->boundingBox->setChecked(bbox);
     ui->blobLabels->setChecked(blobLabels);
-    ui->numLabels->intValue->display(numLabels);
+    ui->numLabels->intValue()->display(numLabels);
   }
   
 }
@@ -48,10 +49,10 @@ CameraSettingsWidget::~CameraSettingsWidget()
 
 void CameraSettingsWidget::plus()
 {
-        ui->numLabels->intValue->display(ui-numLabels->intValue()+1)
+        ui->numLabels->intValue()->display(ui->numLabels->intValue()+1)
 }
 
 void CameraSettingsWidget::minus()
 {
-        ui->numLabels->intValue->display(ui-numLabels->intValue()-1)
+        ui->numLabels->intValue()->display(ui->numLabels->intValue()-1)
 }

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -49,10 +49,10 @@ CameraSettingsWidget::~CameraSettingsWidget()
 
 void CameraSettingsWidget::plus()
 {
-        ui->numLabels->intValue()->display(ui->numLabels->intValue()+1)
+        ui->numLabels->display(ui->numLabels->intValue()+1)
 }
 
 void CameraSettingsWidget::minus()
 {
-        ui->numLabels->intValue()->display(ui->numLabels->intValue()-1)
+        ui->numLabels->display(ui->numLabels->intValue()-1)
 }

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -49,10 +49,10 @@ CameraSettingsWidget::~CameraSettingsWidget()
 
 void CameraSettingsWidget::plus()
 {
-        ui->numLabels->display(ui->numLabels->intValue()+1)
+        ui->numLabels->display(ui->numLabels->intValue()+1);
 }
 
 void CameraSettingsWidget::minus()
 {
-        ui->numLabels->display(ui->numLabels->intValue()-1)
+        ui->numLabels->display(ui->numLabels->intValue()-1);
 }

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -28,7 +28,7 @@ CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent
     
     ui->boundingBox->setChecked(bbox);
     ui->blobLabels->setChecked(blobLabels);
-    ui->numLabels->intValue()->display(numLabels);
+    ui->numLabels->display(numLabels);
   }
   
 }

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -15,6 +15,9 @@ CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent
   ui->setupUi(this);
   performStandardSetup(tr("Camera Settings Widget"));
     
+  connect(ui->plus, SIGNAL(clicked()), SLOT(plus()));
+  connect(ui->minus, SIGNAL(clicked()), SLOT(minus()));
+
   // Set current setting values
   const SettingsProvider *const settingsProvider = device->settingsProvider();
   if(settingsProvider) {
@@ -35,9 +38,20 @@ CameraSettingsWidget::~CameraSettingsWidget()
   if(settingsProvider) {
     settingsProvider->setValue(BOUNDING_BOX_KEY, ui->boundingBox->isChecked());
     settingsProvider->setValue(BLOB_LABELS_KEY, ui->blobLabels->isChecked());
-    settingsProvider->setValue(NUM_BLOB_LABELS_KEY, ui->numLabels->value());
+    settingsProvider->setValue(NUM_BLOB_LABELS_KEY, ui->numLabels->intValue());
     settingsProvider->sync();
   }
   
   delete ui;
+}
+
+
+void CameraSettingsWidget::plus()
+{
+        ui->numLabels->intValue->display(ui-numLabels->intValue()+1)
+}
+
+void CameraSettingsWidget::minus()
+{
+        ui->numLabels->intValue->display(ui-numLabels->intValue()-1)
 }

--- a/src/CameraSettingsWidget.cpp
+++ b/src/CameraSettingsWidget.cpp
@@ -27,7 +27,7 @@ CameraSettingsWidget::CameraSettingsWidget(Device *device, QWidget *const parent
     
     ui->boundingBox->setChecked(bbox);
     ui->blobLabels->setChecked(blobLabels);
-    ui->numLabels->setValue(numLabels);
+    ui->numLabels->intValue->display(numLabels);
   }
   
 }

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -8,6 +8,8 @@
 #include "Calibrate.h"
 #include "Options.h"
 #include "NotYetImplementedDialog.h"
+#include <QString>
+#include <QProcess>
 
 
 #include <QDebug>
@@ -46,7 +48,6 @@ void FactoryWidget::reflash()
     backup_process.startDetached("/bin/sh", QStringList()<< "/home/pi/*_flash.sh");
     backup_process.waitForFinished(); // sets current thread to sleep
     //ui->flashConsole->insertPlainText("Flash Complete");
-    QMessageBox::warning(this, "Flash Complete", "Flash Complete");
 
 }
 

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -17,7 +17,7 @@
 
 FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         : StandardWidget(device, parent),
-        ui(new Ui::AdvancedSettingsWidget)
+        ui(new Ui::FactoryWidget)
 {
         ui->updateConsole->setVisible(false);
 	ui->setupUi(this);

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -6,6 +6,7 @@
 #include <QProcess>
 #include <QFile>
 #include <QFileInfo>
+#include <iostream>
 
 #include "MenuBar.h"
 #include "RootController.h"

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -21,7 +21,7 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         ui->updateConsole->setVisible(false);
 	ui->setupUi(this);
 	
-	ui->serialNumber->setInputProvider(m_serialNumpad);
+        //ui->serialNumber->setInputProvider(serialNumber);
 	connect(ui->confirm, SIGNAL(clicked()), SLOT(confirm()));
         connect(ui->reflash, SIGNAL(clicked()), SLOT(reflash()));
         connect(ui->experimental, SIGNAL(clicked()), SLOT(experimental()));
@@ -29,7 +29,7 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
 
 FactoryWidget::~FactoryWidget()
 {
-	delete m_serialNumpad;
+        //delete serialNumber;
 	delete ui;
 }
 

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -13,7 +13,7 @@
 
 FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
 	: QWidget(parent),
-	m_device(device),
+        //m_device(device),
         //m_serialNumpad(new NumpadDialog(tr("Serial Number"), NumpadDialog::Integer)),
 	ui(new Ui::FactoryWidget)
 {
@@ -25,6 +25,7 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
 	connect(ui->confirm, SIGNAL(clicked()), SLOT(confirm()));
         connect(ui->reflash, SIGNAL(clicked()), SLOT(reflash()));
         connect(ui->experimental, SIGNAL(clicked()), SLOT(experimental()));
+
 }
 
 FactoryWidget::~FactoryWidget()
@@ -47,11 +48,13 @@ void FactoryWidget::confirm()
 
 void FactoryWidget::reflash()
 {
+
     QProcess backup_process;
     backup_process.startDetached("/bin/sh", QStringList()<< "/home/pi/*_flash.sh");
     backup_process.waitForFinished(); // sets current thread to sleep
     ui->updateConsole->insertPlainText("Flash Complete");
     QMessageBox::warning(this, "Flash Complete", "Flash Complete");
+
 }
 
 void FactoryWidget::experimental()

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -14,7 +14,7 @@
 FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
 	: QWidget(parent),
 	m_device(device),
-	m_serialNumpad(new NumpadDialog(tr("Serial Number"), NumpadDialog::Integer)),
+        //m_serialNumpad(new NumpadDialog(tr("Serial Number"), NumpadDialog::Integer)),
 	ui(new Ui::FactoryWidget)
 {
 

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -1,42 +1,31 @@
 #include "FactoryWidget.h"
 #include "ui_FactoryWidget.h"
-
-#include <QApplication>
-#include <QMessageBox>
-#include <QProcess>
-#include <QFile>
-#include <QFileInfo>
-#include <iostream>
-
+#include "SettingsProvider.h"
 #include "MenuBar.h"
 #include "RootController.h"
 #include "StatusBar.h"
 #include "Device.h"
+#include "Calibrate.h"
 #include "Options.h"
 #include "NotYetImplementedDialog.h"
 
+
+#include <QDebug>
 
 FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         : StandardWidget(device, parent),
         ui(new Ui::FactoryWidget)
 {
-        std::cout << "Test 1" << std::endl;
-        //ui->flashConsole->setVisible(false);
-        std::cout << "Test 2" << std::endl;
-	ui->setupUi(this);
-        std::cout << "Test 3" << std::endl;
-        //ui->serialNumber->setInputProvider(serialNumber);
-	connect(ui->confirm, SIGNAL(clicked()), SLOT(confirm()));
+        ui->setupUi(this);
+        performStandardSetup(tr("Factory"));
+
+
+        connect(ui->confirm, SIGNAL(clicked()), SLOT(confirm()));
         connect(ui->reflash, SIGNAL(clicked()), SLOT(reflash()));
         connect(ui->experimental, SIGNAL(clicked()), SLOT(experimental()));
 
 }
 
-FactoryWidget::~FactoryWidget()
-{
-        //delete serialNumber;
-	delete ui;
-}
 
 void FactoryWidget::confirm()
 {

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -7,9 +7,13 @@
 #include <QFile>
 #include <QFileInfo>
 
-#include "Device.h"
-#include "NumpadDialog.h"
+#include "MenuBar.h"
 #include "RootController.h"
+#include "StatusBar.h"
+#include "Device.h"
+#include "Options.h"
+#include "NotYetImplementedDialog.h"
+
 
 FactoryWidget::FactoryWidget(Device *device, QWidget *parent) : StandardWidget(parent), ui(new Ui::FactoryWidget)
 {

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -21,7 +21,7 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         ui(new Ui::FactoryWidget)
 {
         std::cout << "Test 1" << std::endl;
-        ui->flashConsole->setVisible(false);
+        //ui->flashConsole->setVisible(false);
         std::cout << "Test 2" << std::endl;
 	ui->setupUi(this);
         std::cout << "Test 3" << std::endl;
@@ -56,7 +56,7 @@ void FactoryWidget::reflash()
     QProcess backup_process;
     backup_process.startDetached("/bin/sh", QStringList()<< "/home/pi/*_flash.sh");
     backup_process.waitForFinished(); // sets current thread to sleep
-    ui->flashConsole->insertPlainText("Flash Complete");
+    //ui->flashConsole->insertPlainText("Flash Complete");
     QMessageBox::warning(this, "Flash Complete", "Flash Complete");
 
 }

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -15,7 +15,9 @@
 #include "NotYetImplementedDialog.h"
 
 
-FactoryWidget::FactoryWidget(Device *device, QWidget *parent) : StandardWidget(parent), ui(new Ui::FactoryWidget)
+FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
+        : StandardWidget(device, parent),
+        ui(new Ui::AdvancedSettingsWidget)
 {
         ui->updateConsole->setVisible(false);
 	ui->setupUi(this);

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -21,7 +21,7 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         ui(new Ui::FactoryWidget)
 {
         std::cout << "Test 1" << std::endl;
-        ui->updateConsole->setVisible(false);
+        ui->flashConsole->setVisible(false);
         std::cout << "Test 2" << std::endl;
 	ui->setupUi(this);
         std::cout << "Test 3" << std::endl;

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -56,7 +56,7 @@ void FactoryWidget::reflash()
     QProcess backup_process;
     backup_process.startDetached("/bin/sh", QStringList()<< "/home/pi/*_flash.sh");
     backup_process.waitForFinished(); // sets current thread to sleep
-    ui->updateConsole->insertPlainText("Flash Complete");
+    ui->flashConsole->insertPlainText("Flash Complete");
     QMessageBox::warning(this, "Flash Complete", "Flash Complete");
 
 }

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -19,9 +19,11 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
         : StandardWidget(device, parent),
         ui(new Ui::FactoryWidget)
 {
+        std::cout << "Test 1" << std::endl;
         ui->updateConsole->setVisible(false);
+        std::cout << "Test 2" << std::endl;
 	ui->setupUi(this);
-	
+        std::cout << "Test 3" << std::endl;
         //ui->serialNumber->setInputProvider(serialNumber);
 	connect(ui->confirm, SIGNAL(clicked()), SLOT(confirm()));
         connect(ui->reflash, SIGNAL(clicked()), SLOT(reflash()));

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -28,6 +28,10 @@ FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
 
 }
 
+FactoryWidget::~FactoryWidget()
+{
+        delete ui;
+}
 
 void FactoryWidget::confirm()
 {

--- a/src/FactoryWidget.cpp
+++ b/src/FactoryWidget.cpp
@@ -11,13 +11,8 @@
 #include "NumpadDialog.h"
 #include "RootController.h"
 
-FactoryWidget::FactoryWidget(Device *device, QWidget *parent)
-	: QWidget(parent),
-        //m_device(device),
-        //m_serialNumpad(new NumpadDialog(tr("Serial Number"), NumpadDialog::Integer)),
-	ui(new Ui::FactoryWidget)
+FactoryWidget::FactoryWidget(Device *device, QWidget *parent) : StandardWidget(parent), ui(new Ui::FactoryWidget)
 {
-
         ui->updateConsole->setVisible(false);
 	ui->setupUi(this);
 	

--- a/ui/CameraSettingsWidget.ui
+++ b/ui/CameraSettingsWidget.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Camera Settings</string>
   </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>6</number>
@@ -82,7 +85,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0">
      <item>
       <widget class="QLabel" name="label">
        <property name="font">
@@ -96,23 +99,124 @@
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="numLabels">
+      <widget class="QFrame" name="frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>40</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::Box</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <property name="lineWidth">
+        <number>3</number>
+       </property>
+       <widget class="QLCDNumber" name="numLabels">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>0</y>
+          <width>52</width>
+          <height>69</height>
+         </rect>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="lineWidth">
+         <number>1</number>
+        </property>
+        <property name="digitCount">
+         <number>2</number>
+        </property>
+        <property name="intValue" stdset="0">
+         <number>1</number>
+        </property>
+       </widget>
+       <widget class="QLabel" name="label_2">
+        <property name="geometry">
+         <rect>
+          <x>90</x>
+          <y>0</y>
+          <width>142</width>
+          <height>69</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <family>Noto Sans</family>
+          <pointsize>33</pointsize>
+         </font>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>1</number>
+        </property>
+        <property name="text">
+         <string>Blob(s)</string>
+        </property>
+       </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="minus">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="font">
         <font>
+         <family>Noto Sans</family>
          <pointsize>33</pointsize>
         </font>
        </property>
-       <property name="suffix">
-        <string> blob(s)</string>
+       <property name="text">
+        <string>-</string>
        </property>
-       <property name="prefix">
-        <string> </string>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="plus">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="minimum">
-        <number>1</number>
+       <property name="font">
+        <font>
+         <family>Noto Sans</family>
+         <pointsize>33</pointsize>
+        </font>
        </property>
-       <property name="maximum">
-        <number>10</number>
+       <property name="text">
+        <string>+</string>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>35</width>
+         <height>35</height>
+        </size>
        </property>
       </widget>
      </item>

--- a/ui/CameraSettingsWidget.ui
+++ b/ui/CameraSettingsWidget.ui
@@ -118,7 +118,7 @@
        <widget class="QLCDNumber" name="numLabels">
         <property name="geometry">
          <rect>
-          <x>20</x>
+          <x>10</x>
           <y>0</y>
           <width>52</width>
           <height>69</height>
@@ -143,7 +143,7 @@
        <widget class="QLabel" name="label_2">
         <property name="geometry">
          <rect>
-          <x>90</x>
+          <x>70</x>
           <y>0</y>
           <width>142</width>
           <height>69</height>

--- a/ui/CameraSettingsWidget.ui
+++ b/ui/CameraSettingsWidget.ui
@@ -145,7 +145,7 @@
          <rect>
           <x>70</x>
           <y>0</y>
-          <width>142</width>
+          <width>151</width>
           <height>69</height>
          </rect>
         </property>

--- a/ui/FactoryWidget.ui
+++ b/ui/FactoryWidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Factory</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0,0">
    <property name="leftMargin">
     <number>6</number>
    </property>
@@ -162,6 +162,32 @@
     </widget>
    </item>
    <item>
+    <widget class="ConsoleWidget" name="updateConsole">
+     <property name="minimumSize">
+      <size>
+       <width>450</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <family>Courier New</family>
+       <pointsize>22</pointsize>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -175,40 +201,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
-     <widget class="ConsoleWidget" name="updateConsole">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>450</width>
-        <height>478</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>450</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>22</pointsize>
-        <italic>true</italic>
-       </font>
-      </property>
-      <property name="undoRedoEnabled">
-       <bool>false</bool>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-      <property name="acceptRichText">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </widget>
+    <widget class="QWidget" name="widget" native="true"/>
    </item>
   </layout>
  </widget>

--- a/ui/FactoryWidget.ui
+++ b/ui/FactoryWidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Factory</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0">
    <property name="leftMargin">
     <number>6</number>
    </property>
@@ -162,32 +162,6 @@
     </widget>
    </item>
    <item>
-    <widget class="ConsoleWidget" name="flashConsole">
-     <property name="minimumSize">
-      <size>
-       <width>450</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>Courier New</family>
-       <pointsize>22</pointsize>
-       <italic>true</italic>
-      </font>
-     </property>
-     <property name="undoRedoEnabled">
-      <bool>false</bool>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="acceptRichText">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -210,11 +184,6 @@
    <class>LineEdit</class>
    <extends>QLineEdit</extends>
    <header>LineEdit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ConsoleWidget</class>
-   <extends>QTextEdit</extends>
-   <header>ConsoleWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/ui/FactoryWidget.ui
+++ b/ui/FactoryWidget.ui
@@ -162,7 +162,7 @@
     </widget>
    </item>
    <item>
-    <widget class="ConsoleWidget" name="updateConsole">
+    <widget class="ConsoleWidget" name="flashConsole">
      <property name="minimumSize">
       <size>
        <width>450</width>


### PR DESCRIPTION
The factory page was setup wrong, I thought I could just use the "factory widget" that was lost in production but it did not use the StandardWidget model. The UI would crash when opening the page, now it doesn't. I will have to make the buttons functional in a future release.