### PR TITLE
[erinQt6Upgrade] Update camera widgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ cmake_minimum_required(VERSION 2.8.11)
 if(wombat)
 	add_definitions(-DWOMBAT)
 	set(DEVICE_DIR ${CMAKE_SOURCE_DIR}/devices/wombat)
-	find_package(OpenCV REQUIRED)
 endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/deploy)
@@ -123,7 +122,7 @@ IF(qt6)
 	target_link_libraries(botui Qt6::Core Qt6::Gui Qt6::Quick Qt6::QuickWidgets Qt6::Widgets)
 
 ENDIF()
-target_link_libraries(botui pcompiler z opencv_core opencv_highgui opencv_imgproc ${OPENSSL_LIBRARIES})
+target_link_libraries(botui pcompiler z ${OPENSSL_LIBRARIES})
 
 
 IF(wombat)
@@ -138,5 +137,3 @@ endif()
 
 install(TARGETS botui DESTINATION bin)
 install(FILES ${QM_FILES} DESTINATION "/etc/botui/locale")
-
-message( STATUS "OpenCV Include Dir: " ${OpenCV_INCLUDE_DIRS} )

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Requirements
 ============
 * [pcompiler ](https://github.com/kipr/pcompiler)
 * CMake 2.6.0 or later
-* OpenCV
 * [Qt >= 4.7.4](https://www.qt.io/download-qt-installer)
 
 

--- a/include/botui/BuildOptions.h
+++ b/include/botui/BuildOptions.h
@@ -7,6 +7,4 @@
 #define ENABLE_DBUS_SUPPORT
 #endif
 
-#define ENABLE_OPENCV_SUPPORT
-
 #endif

--- a/include/botui/CameraImageWidget.h
+++ b/include/botui/CameraImageWidget.h
@@ -1,5 +1,5 @@
-#ifndef _CVWIDGET_H_
-#define _CVWIDGET_H_
+#ifndef _CAMERAIMAGEWIDGET_H_
+#define _CAMERAIMAGEWIDGET_H_
 
 #include <QImage>
 #include <QWidget>
@@ -7,13 +7,13 @@
 
 #include <kipr/camera/camera.hpp>
 
-class CvWidget : public QWidget
+class CameraImageWidget : public QWidget
 {
 Q_OBJECT
 Q_PROPERTY(bool invalid READ invalid WRITE setInvalid)
 public:
-	CvWidget(QWidget *parent = 0);
-	~CvWidget();
+	CameraImageWidget(QWidget *parent = 0);
+	~CameraImageWidget();
 	
 	void setInvalid(bool invalid);
 	const bool& invalid() const;

--- a/include/botui/CameraWidget.h
+++ b/include/botui/CameraWidget.h
@@ -32,6 +32,9 @@ public:
   
 public slots:
   void update();
+
+protected:
+  void postProcessImage(QImage &image) override;
   
 private:
   void setFrameRate(const unsigned frameRate);

--- a/include/botui/CameraWidget.h
+++ b/include/botui/CameraWidget.h
@@ -1,7 +1,7 @@
 #ifndef _CAMERAWIDGET_H_
 #define _CAMERAWIDGET_H_
 
-#include "CvWidget.h"
+#include "CameraImageWidget.h"
 
 #include <QTimer>
 
@@ -14,7 +14,7 @@ namespace kipr::camera
 	class Device;
 }
 
-class CameraWidget : public CvWidget
+class CameraWidget : public CameraImageWidget
 {
 Q_OBJECT
 public:

--- a/include/botui/CvWidget.h
+++ b/include/botui/CvWidget.h
@@ -4,7 +4,8 @@
 #include <QImage>
 #include <QWidget>
 #include <QMutex>
-#include <opencv4/opencv2/opencv.hpp>
+
+#include <kipr/camera/camera.hpp>
 
 class CvWidget : public QWidget
 {
@@ -18,22 +19,22 @@ public:
 	const bool& invalid() const;
 	
 public slots:
-	void updateImage(const cv::Mat &image);
+	void updateImage(const kipr::camera::Image &image);
 	
 signals:
-	void pressed(const cv::Mat &image, const int &x, const int &y);
+	void pressed(const kipr::camera::Image &image, const int &x, const int &y);
 	
 protected:
 	virtual void resizeEvent(QResizeEvent *event);
 	virtual void paintEvent(QPaintEvent *event);
 	virtual void mousePressEvent(QMouseEvent *event);
+	virtual void postProcessImage(QImage &image);
 	
 private:
-	void scaleImage();
+	void prepareImageForPainting();
 	
 	bool m_invalid;
-	cv::Mat m_image;
-	unsigned char *m_data;
+	kipr::camera::Image m_image;
 	QImage m_resizedImage;
 	mutable QMutex m_mutex;
 };

--- a/include/botui/HsvChannelConfigWidget.h
+++ b/include/botui/HsvChannelConfigWidget.h
@@ -3,7 +3,7 @@
 
 #include "ChannelConfigWidget.h"
 
-#include <opencv2/core/core.hpp>
+#include <kipr/camera/image.hpp>
 
 namespace Ui
 {
@@ -29,7 +29,7 @@ private slots:
 	
 	void visualChanged();
 	
-	void imagePressed(const cv::Mat &image, const int &x, const int &y);
+	void imagePressed(const kipr::camera::Image &image, const int &x, const int &y);
 	
 	void done();
 	

--- a/src/CameraImageWidget.cpp
+++ b/src/CameraImageWidget.cpp
@@ -1,31 +1,31 @@
-#include "CvWidget.h"
+#include "CameraImageWidget.h"
 
 #include <QPainter>
 #include <QDebug>
 #include <QMouseEvent>
 
-CvWidget::CvWidget(QWidget *parent)
+CameraImageWidget::CameraImageWidget(QWidget *parent)
 	: QWidget(parent),
 	m_invalid(true)
 {
 }
 
-CvWidget::~CvWidget()
+CameraImageWidget::~CameraImageWidget()
 {
 
 }
 
-void CvWidget::setInvalid(bool invalid)
+void CameraImageWidget::setInvalid(bool invalid)
 {
 	m_invalid = invalid;
 }
 
-const bool& CvWidget::invalid() const
+const bool& CameraImageWidget::invalid() const
 {
 	return m_invalid;
 }
 
-void CvWidget::updateImage(const kipr::camera::Image &image)
+void CameraImageWidget::updateImage(const kipr::camera::Image &image)
 {
 	m_mutex.lock();
 	m_invalid = image.isEmpty();
@@ -41,14 +41,14 @@ void CvWidget::updateImage(const kipr::camera::Image &image)
 	m_mutex.unlock();
 }
 
-void CvWidget::resizeEvent(QResizeEvent *event)
+void CameraImageWidget::resizeEvent(QResizeEvent *event)
 {
 	if (!m_invalid) this->prepareImageForPainting();
 
 	QWidget::resizeEvent(event);
 }
 
-void CvWidget::paintEvent(QPaintEvent *event)
+void CameraImageWidget::paintEvent(QPaintEvent *event)
 {
 	QPainter painter(this);
 	
@@ -66,7 +66,7 @@ void CvWidget::paintEvent(QPaintEvent *event)
 		m_resizedImage.width() - 1, m_resizedImage.height() - 1);
 }
 
-void CvWidget::mousePressEvent(QMouseEvent *event)
+void CameraImageWidget::mousePressEvent(QMouseEvent *event)
 {
 	if(m_invalid) return;
 	const QPointF &pos = event->pos();
@@ -74,12 +74,12 @@ void CvWidget::mousePressEvent(QMouseEvent *event)
 		pos.y() / height() * m_image.getHeight());
 }
 
-void CvWidget::postProcessImage(QImage &image)
+void CameraImageWidget::postProcessImage(QImage &image)
 {
-	// No-op for CvWidget, but subclasses can override it to augment the displayed image
+	// No-op for CameraImageWidget, but subclasses can override it to augment the displayed image
 }
 
-void CvWidget::prepareImageForPainting()
+void CameraImageWidget::prepareImageForPainting()
 {
 	QImage::Format format;
 	switch (m_image.getType()) {

--- a/src/CameraWidget.cpp
+++ b/src/CameraWidget.cpp
@@ -9,7 +9,7 @@
 #include <kipr/camera/object.hpp>
 
 CameraWidget::CameraWidget(QWidget *parent)
-  : CvWidget(parent),
+  : CameraImageWidget(parent),
   m_camDevice(new kipr::camera::Device()),
   m_timer(new QTimer(this))
 {  
@@ -149,5 +149,5 @@ void CameraWidget::slowFrameRate()
 
 void CameraWidget::fastFrameRate()
 {
-  this->setFrameRate(10);
+  this->setFrameRate(1);
 }

--- a/src/HsvChannelConfigWidget.cpp
+++ b/src/HsvChannelConfigWidget.cpp
@@ -7,9 +7,6 @@
 
 #include <kipr/camera/camera.h>
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-
 #include <QDebug>
 
 HsvChannelConfigWidget::HsvChannelConfigWidget(const QModelIndex &index, QWidget *parent)
@@ -42,7 +39,7 @@ HsvChannelConfigWidget::HsvChannelConfigWidget(const QModelIndex &index, QWidget
 	connect(ui->visual, SIGNAL(minChanged(QColor)), SLOT(visualChanged()));
 	connect(ui->visual, SIGNAL(maxChanged(QColor)), SLOT(visualChanged()));
 	
-	connect(ui->camera, SIGNAL(pressed(cv::Mat, int, int)), SLOT(imagePressed(cv::Mat, int, int)));
+	connect(ui->camera, SIGNAL(pressed(kipr::camera::Image, int, int)), SLOT(imagePressed(kipr::camera::Image, int, int)));
 	
 	connect(ui->done, SIGNAL(clicked()), SLOT(done()));
 	
@@ -180,11 +177,34 @@ void HsvChannelConfigWidget::visualChanged()
 	blockChildSignals(false);
 }
 
-void HsvChannelConfigWidget::imagePressed(const cv::Mat &image, const int &x, const int &y)
+void HsvChannelConfigWidget::imagePressed(const kipr::camera::Image &image, const int &x, const int &y)
 {
-  // This is RGB, not BGR
-	cv::Vec3b data = image.at<cv::Vec3b>(y, x);
-	const QColor c(data[0], data[1], data[2]);
+	unsigned char r;
+	unsigned char g;
+	unsigned char b;
+
+	switch (image.getType()) {
+	case kipr::camera::Image::Type::Bgr888: {
+		const unsigned char *const data = image.getData() + y * image.getStride() + x * 3;
+		r = data[2];
+		g = data[1];
+		b = data[0];
+		break;
+	}
+	case kipr::camera::Image::Type::Rgb888: {
+		const unsigned char *const data = image.getData() + y * image.getStride() + x * 3;
+		r = data[0];
+		g = data[1];
+		b = data[2];
+		break;
+	}
+	default: {
+		qWarning() << "Unsupported image format";
+		return;
+	}
+	}
+	
+	const QColor c(r, g, b);
 	
 	int th = (c.hue() / 2 + 5) % 180;
 	int ts = c.saturation() + 40;

--- a/ts/botui_en.ts
+++ b/ts/botui_en.ts
@@ -525,9 +525,9 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
-    <name>CvWidget</name>
+    <name>CameraImageWidget</name>
     <message>
-        <location filename="src/CvWidget.cpp" line="63"/>
+        <location filename="src/CameraImageWidget.cpp" line="63"/>
         <source>Failed to fetch image</source>
         <translation></translation>
     </message>

--- a/ts/botui_zh.ts
+++ b/ts/botui_zh.ts
@@ -658,13 +658,13 @@ p, li { white-space: pre-wrap; }
     </message>
 </context>
 <context>
-    <name>CvWidget</name>
+    <name>CameraImageWidget</name>
     <message>
         <source>Failed to fetch image</source>
         <translation type="obsolete">获取图像失败</translation>
     </message>
     <message>
-        <location filename="src/CvWidget.cpp" line="63"/>
+        <location filename="src/CameraImageWidget.cpp" line="63"/>
         <source>No image available. Check camera connection.</source>
         <translation>无可用图像,请检查摄像头连接</translation>
     </message>


### PR DESCRIPTION
(to be merged into `erinQt6Upgrade`, not `master`)

Update camera widgets to use the new libwallaby `Image` interface instead of OpenCV.

- Rename `CvWidget` to `CameraImageWidget`
- Update `CameraImageWidget` to use `QImage` instead of OpenCV for image operations
- Remove dependency on OpenCV

Remaining issues
- Untested on wallaby with Qt 6
- Blob boxes/labels are drawn before scaling, so they may not be sharp