### PR TITLE
Qt6 Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ deploy
 lib
 obj-arm-linux-gnueabihf
 .vscode
+out
+toolchain.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 deploy
 lib
 obj-arm-linux-gnueabihf
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj-arm-linux-gnueabihf
 .vscode
 out
 toolchain.cmake
+build2

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
-                "/usr/include/x86_64-linux-gnu/qt6/QtDBus"
+                "/home/eliot/qt-pinoexample/include"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,13 @@
         "list": "cpp",
         "array": "cpp",
         "string_view": "cpp",
-        "string": "cpp"
+        "string": "cpp",
+        "hash_map": "cpp",
+        "deque": "cpp",
+        "unordered_map": "cpp",
+        "vector": "cpp",
+        "initializer_list": "cpp",
+        "functional": "cpp",
+        "utility": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,14 @@ cmake_minimum_required(VERSION 2.8.11)
 if(wombat)
 	add_definitions(-DWOMBAT)
 	set(DEVICE_DIR ${CMAKE_SOURCE_DIR}/devices/wombat)
+
+	# eliot stuff
+	include_directories(/home/eliot/Documents/GitHub/libkar/out/include)
+	include_directories(/home/eliot/Documents/GitHub/pcompiler/out/include)
+	include_directories(/home/eliot/rpi-sysroot/usr/local/include)
+	link_directories(/home/eliot/Documents/GitHub/libkar/out/lib)
+	link_directories(/home/eliot/Documents/GitHub/pcompiler/out/lib)
+	link_directories(/home/eliot/rpi-sysroot/usr/local/lib)
 endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/deploy)
@@ -110,9 +118,9 @@ target_link_libraries(botui
 	${OPENSSL_LIBRARIES}
 )
 
-IF(wombat)
-  target_link_libraries(botui kipr)
-ENDIF()
+
+target_link_libraries(botui kipr)
+
 
 target_link_libraries(botui ${QT_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,14 +18,6 @@ cmake_minimum_required(VERSION 2.8.11)
 if(wombat)
 	add_definitions(-DWOMBAT)
 	set(DEVICE_DIR ${CMAKE_SOURCE_DIR}/devices/wombat)
-
-	# eliot stuff
-	include_directories(/home/eliot/Documents/GitHub/libkar/out/include)
-	include_directories(/home/eliot/Documents/GitHub/pcompiler/out/include)
-	include_directories(/home/eliot/rpi-sysroot/usr/local/include)
-	link_directories(/home/eliot/Documents/GitHub/libkar/out/lib)
-	link_directories(/home/eliot/Documents/GitHub/pcompiler/out/lib)
-	link_directories(/home/eliot/rpi-sysroot/usr/local/lib)
 endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/deploy)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 * [pcompiler ](https://github.com/kipr/pcompiler)
 * CMake 2.6.0 or later
 * [Qt >= 4.7.4](https://www.qt.io/download-qt-installer)
-
+* Note: for Qt6, the apt packages needed are `qt6-base qt6-declarative libqt6svg6-dev`
 
 Installation
 =======

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 * [pcompiler ](https://github.com/kipr/pcompiler)
 * CMake 2.6.0 or later
 * [Qt >= 4.7.4](https://www.qt.io/download-qt-installer)
-* Note: for Qt6, the apt packages needed are `qt6-base qt6-declarative libqt6svg6-dev`
+* Note: for Qt6, the apt packages needed are `qt6-base-dev qt6-declarative libqt6svg6-dev`
 
 Installation
 =======

--- a/include/botui/ConnectionedARDroneInputProvider.h
+++ b/include/botui/ConnectionedARDroneInputProvider.h
@@ -1,7 +1,7 @@
 #ifndef _CONNECTIONEDARDRONEINPUTPROVIDER_H_
 #define _CONNECTIONEDARDRONEINPUTPROVIDER_H_
 /* FIXME
-#ifdef WALLABY
+#ifdef WOMBAT
 #include <wallaby/ardrone.hpp>
 #else
 #include <kovan/ardrone.hpp>

--- a/include/botui/NetworkManager.h
+++ b/include/botui/NetworkManager.h
@@ -19,9 +19,10 @@ class OrgFreedesktopNetworkManagerDeviceWirelessInterface;
 
 class NetworkManager : public QObject, public Singleton<NetworkManager>
 {
-Q_OBJECT
+	Q_OBJECT
 public:
-	enum State {
+	enum State
+	{
 		Unknown = 0,
 		Unmanaged = 10,
 		Unavailable = 20,
@@ -36,65 +37,63 @@ public:
 		Deactivating = 110,
 		Failed = 120
 	};
-	
+
 	NetworkManager();
 	~NetworkManager();
-	
+
 	void addNetwork(const Network &network);
 	void forgetNetwork(const Network &network);
 	NetworkList networks() const;
-	
+
 	Network active() const;
-	
+
 	void requestScan();
-	
+
 	bool isOn() const;
 	bool isPersistentOn() const;
-	
+
 	State state() const;
-	
+
 	NetworkList accessPoints() const;
-	
+
 	QString ipAddress() const;
 
 	QString ip4Address() const;
 
-	Connection createAPConfig() const ;
-
-	QString currentActiveConnectionName() const;
+	Connection createAPConfig() const;
 
 	bool isActiveConnectionOn() const;
-	
+	bool isActiveConnectionAP() const;
+
 public slots:
 	bool turnOn();
 	void turnOff();
-	
+
 	bool enableAP();
 	bool disableAP();
-
 
 signals:
 	void networkAdded(const Network &network);
 	void networkForgotten(const Network &network);
-	
+
 	void accessPointAdded(const Network &network);
 	void accessPointRemoved(const Network &network);
-	
+
 	void stateChanged(const NetworkManager::State &newState, const NetworkManager::State &oldState);
-	
+
 private slots:
 	void nmAccessPointAdded(const QDBusObjectPath &path);
 	void nmAccessPointRemoved(const QDBusObjectPath &path);
-	
+
 	void stateChangedBouncer(uint newState, uint oldState);
-	
+
 private:
 	Network networkFromConnection(const Connection &connection) const;
 	Network createAccessPoint(const QDBusObjectPath &accessPoint) const;
-	
+
 	NetworkList m_accessPoints;
 	QDBusObjectPath devicePath;
-	
+
 	OrgFreedesktopNetworkManagerInterface *m_nm;
 	OrgFreedesktopNetworkManagerDeviceInterface *m_device;
 	OrgFreedesktopNetworkManagerDeviceWirelessInterface *m_wifi;

--- a/include/botui/NetworkManager.h
+++ b/include/botui/NetworkManager.h
@@ -2,6 +2,8 @@
 #define _NETWORKMANAGER_H_
 
 #include "Options.h"
+#include "Device.h"
+#include "SystemUtils.h"
 
 #ifdef NETWORK_ENABLED
 
@@ -40,12 +42,14 @@ public:
 
 	NetworkManager();
 	~NetworkManager();
+	void init(const Device *device);
 
 	void addNetwork(const Network &network);
 	void forgetNetwork(const Network &network);
 	NetworkList networks() const;
 
 	Network active() const;
+	QString activeConnectionPassword() const;
 
 	void requestScan();
 
@@ -57,7 +61,6 @@ public:
 	NetworkList accessPoints() const;
 
 	QString ipAddress() const;
-
 	QString ip4Address() const;
 
 	Connection createAPConfig() const;
@@ -97,6 +100,8 @@ private:
 	OrgFreedesktopNetworkManagerInterface *m_nm;
 	OrgFreedesktopNetworkManagerDeviceInterface *m_device;
 	OrgFreedesktopNetworkManagerDeviceWirelessInterface *m_wifi;
+
+	const Device *m_dev;
 };
 
 #endif

--- a/include/botui/NetworkSettingsWidget.h
+++ b/include/botui/NetworkSettingsWidget.h
@@ -20,30 +20,29 @@ namespace Ui
 
 class NetworkSettingsWidget : public StandardWidget
 {
-Q_OBJECT
+	Q_OBJECT
 public:
 	NetworkSettingsWidget(Device *device, QWidget *parent = 0);
 	~NetworkSettingsWidget();
-	
+
 public slots:
 	void TournamentMode();
 	void connect();
 	void manage();
 	void updateInformation();
 
-
-	
 private slots:
 	void stateChanged(const NetworkManager::State &newState, const NetworkManager::State &oldState);
 	void indexChanged(int index);
+
 private:
 	Ui::NetworkSettingsWidget *ui;
 	QTimer *enableCoolOffTimer;
 	QProcess proc;
 	QMessageBox msgBox;
-	
+	bool firstTimeSetup;
+	void setupConnectionModeSelect();
 };
-
 
 #endif
 

--- a/include/botui/RootController.h
+++ b/include/botui/RootController.h
@@ -52,11 +52,8 @@ public slots:
 
 	void dismissWidget();
 	void dismissAllWidgets();
-	void findNetworkSettingsWidget() const;
-	void addNetworkSettingsStack(NetworkSettingsWidget *networkWidget) ;
 	void minimize();
 	void printStack();
-	void getNetworkSettingsWidget();
 
 private:
 	void constrain(QWidget *widget);

--- a/src/AdvancedSettingsWidget.cpp
+++ b/src/AdvancedSettingsWidget.cpp
@@ -16,51 +16,49 @@
 
 #include <QDebug>
 
-
 AdvancedSettingsWidget::AdvancedSettingsWidget(Device *device, QWidget *parent)
-	: StandardWidget(device, parent),
-        ui(new Ui::AdvancedSettingsWidget)
+    : StandardWidget(device, parent),
+      ui(new Ui::AdvancedSettingsWidget)
 {
-	ui->setupUi(this);
+        ui->setupUi(this);
         performStandardSetup(tr("Advanced Settings"));
 
-  #ifdef NETWORK_ENABLED
-  ui->network->setEnabled(true);
-  #else
-  ui->network->setEnabled(true);
-  #endif
-  
-	connect(ui->network, SIGNAL(clicked()), SLOT(network()));
+#ifdef NETWORK_ENABLED
+        ui->network->setEnabled(true);
+#else
+        ui->network->setEnabled(true);
+#endif
+
+        connect(ui->network, SIGNAL(clicked()), SLOT(network()));
         connect(ui->factory, SIGNAL(clicked()), SLOT(factory()));
-	connect(ui->gui, SIGNAL(clicked()), SLOT(gui()));
+        connect(ui->gui, SIGNAL(clicked()), SLOT(gui()));
         connect(ui->battery, SIGNAL(clicked()), SLOT(battery()));
-	
 }
 
 AdvancedSettingsWidget::~AdvancedSettingsWidget()
 {
-	delete ui;
+        delete ui;
 }
 
 void AdvancedSettingsWidget::network()
 {
 #ifdef NETWORK_ENABLED
- RootController::ref().getNetworkSettingsWidget();
+        RootController::ref().presentWidget(new NetworkSettingsWidget(device()));
 
 #endif
 }
 
 void AdvancedSettingsWidget::gui()
 {
-	RootController::ref().presentWidget(new GuiSettingsWidget(device()));
+        RootController::ref().presentWidget(new GuiSettingsWidget(device()));
 }
 
 void AdvancedSettingsWidget::battery()
 {
-  RootController::ref().presentWidget(new BatterySettingsWidget(device()));
+        RootController::ref().presentWidget(new BatterySettingsWidget(device()));
 }
 
 void AdvancedSettingsWidget::factory()
 {
-  RootController::ref().presentWidget(new FactoryWidget(device()));
+        RootController::ref().presentWidget(new FactoryWidget(device()));
 }

--- a/src/DepthImageView.cpp
+++ b/src/DepthImageView.cpp
@@ -3,7 +3,7 @@
 #include <QPainter>
 #include <QDebug>
 
-#ifdef WALLABY
+#ifdef WOMBAT
 #include <wallaby/depth_image.hpp>
 #else
 #include <kovan/depth_image.hpp>

--- a/src/DepthSensorWidget.cpp
+++ b/src/DepthSensorWidget.cpp
@@ -2,7 +2,7 @@
 #include "DepthSensorWidget.h"
 #include "ui_DepthSensorWidget.h"
 
-#ifdef WALLABY
+#ifdef WOMBAT
 #include <wallaby/depth_driver.hpp>
 #else
 #include <kovan/depth_driver.hpp>

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -67,13 +67,16 @@
 #define NM_OBJECT "/org/freedesktop/NetworkManager"
 
 #ifndef WOMBAT
-#define WIFI_DEVICE "wlp3s0" // varies per pc
+#define WIFI_DEVICE "wlp3s0" // varies per pc, almost always need to change this on different computers
+#define AP_NAME "COOL_NETWORK"
+#define AP_SSID QByteArray("COOL_NETWORK")
+#define AP_PASSWORD "COOL_PASSWORD"
 #else
 #define WIFI_DEVICE "wlan0" // always wlan0 for raspberry pi
-#endif
 #define AP_NAME m_dev->serial() + "-wombat"
 #define AP_SSID (m_dev->serial() + "-wombat").toUtf8()
 #define AP_PASSWORD SystemUtils::sha256(m_dev->id()).left(6) + "00"
+#endif
 
 NetworkManager::~NetworkManager()
 {

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -65,9 +65,9 @@
 #define NM_SERVICE "org.freedesktop.NetworkManager"
 #define NM_OBJECT "/org/freedesktop/NetworkManager"
 
-#define AP_NAME "COOLNAME"
+#define AP_NAME "COOL_NAME"
 #define AP_SSID QByteArray("COOL_SSID")
-#define AP_PASSWORD "COOLPASSWORD"
+#define AP_PASSWORD "COOL_PASSWORD"
 
 NetworkManager::~NetworkManager()
 {
@@ -207,7 +207,7 @@ void NetworkManager::addNetwork(const Network &network)
       reply.waitForFinished();
       if (reply.isError())
       {
-        qDebug() << "ERROR!!!" << thing.error();
+        qDebug() << "ERROR!!!" << reply.error();
       }
 
       // m_nm->AddAndActivateConnection(apCon, devicePath, QDBusObjectPath("/Settings/21"));

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -325,10 +325,6 @@ void NetworkManager::turnOff()
 
 bool NetworkManager::enableAP()
 {
-#ifdef WALLABY
-  int ret = system("sudo /usr/bin/python /usr/bin/wifi_configurator.py &");
-  return (ret == 0);
-#endif
   Connection defaultAPConfig = createAPConfig();
   Network APN = networkFromConnection(defaultAPConfig);
   addNetwork(APN);
@@ -337,10 +333,6 @@ bool NetworkManager::enableAP()
 
 bool NetworkManager::disableAP()
 {
-#ifdef WALLABY
-  int ret = system("sudo ifconfig wlan0 down");
-  return (ret == 0);
-#endif
   QDBusObjectPath curCon = m_device->activeConnection();
   m_nm->DeactivateConnection(curCon);
   return true;

--- a/src/NetworkSettingsWidget.cpp
+++ b/src/NetworkSettingsWidget.cpp
@@ -25,7 +25,6 @@ NetworkSettingsWidget::NetworkSettingsWidget(Device *device, QWidget *parent)
 	ui->setupUi(this);
 	performStandardSetup(tr("Network Settings"));
 
-	
 	enableCoolOffTimer = new QTimer(this);
 	enableCoolOffTimer->setSingleShot(true);
 	QObject::connect(enableCoolOffTimer, SIGNAL(timeout()), SLOT(enableAPControls()));
@@ -120,7 +119,6 @@ void NetworkSettingsWidget::updateInformation()
 		{
 			ui->ssid->setText(NetworkManager::ref().currentActiveConnectionName());
 			ui->ip->setText(NetworkManager::ref().ip4Address());
-		
 		}
 	}
 	Network active = NetworkManager::ref().active();

--- a/src/NetworkSettingsWidget.cpp
+++ b/src/NetworkSettingsWidget.cpp
@@ -146,16 +146,6 @@ void NetworkSettingsWidget::updateInformation()
 	ui->security->setText("");
 	ui->password->setText("");
 
-	const QString id = device()->id();
-	const QString serial = device()->serial();
-	// if (!id.isEmpty())
-	// {
-	// 	const QString password = SystemUtils::sha256(id).left(6) + "00";
-	// 	const QString ssid = serial + "-wombat";
-	// 	ui->ssid->setText(ssid);
-	// 	ui->password->setText(password);
-	// }
-
 	if (NetworkManager::ref().isActiveConnectionOn()) // if there's an active connection
 	{
 		Network active = NetworkManager::ref().active();
@@ -163,8 +153,8 @@ void NetworkSettingsWidget::updateInformation()
 		ui->ip->setText(NetworkManager::ref().ip4Address());
 		ui->security->setText(active.securityString());
 
-		qDebug() << "apparently password is " << active.password();
-		ui->password->setText(active.password());
+		QString password = NetworkManager::ref().activeConnectionPassword();
+		ui->password->setText(password);
 	}
 }
 

--- a/src/RootController.cpp
+++ b/src/RootController.cpp
@@ -34,30 +34,6 @@ int RootController::presentDialog(QDialog *dialog)
 	return ret;
 }
 
-void RootController::findNetworkSettingsWidget() const
-{
-}
-
-void RootController::addNetworkSettingsStack(NetworkSettingsWidget *networkWidget)
-{
-	m_stack.push(networkWidget);
-}
-
-void RootController::getNetworkSettingsWidget()
-{
-	QWidget *prev = m_stack.size() ? m_stack.top() : 0;
-	printStack();
-	foreach (QWidget *widge, m_stack)
-	{
-
-		if (widge->objectName() == "NetworkSettingsWidget")
-		{
-			constrain(widge);
-			widge->move(prev->pos());
-			present(widge);
-		}
-	}
-}
 void RootController::printStack()
 {
 	foreach (QWidget *widge, m_stack)
@@ -90,37 +66,27 @@ void RootController::dismissWidget()
 	// QWidget *widget = m_stack.pop();
 
 	QWidget *widget = m_stack.top(); // reference to top of stack
-	
-	if (widget->objectName() == "NetworkSettingsWidget")
-	{
-		widget->hide();
-	}
-	else
-	{
-		widget = m_stack.pop();
-		qDebug() << "Trying to dismiss Widget: " << widget->objectName();
-		QWidget *next = m_stack.size() ? m_stack.top() : 0;
-		qDebug() << "Next Widget is:" << next->objectName();
-		if (next)
-			next->move(widget->pos());
 
-		if(next->objectName() != "NetworkSettingsWidget")
-		{
-			present(next);
-		}
+	widget = m_stack.pop();
+	qDebug() << "Trying to dismiss Widget: " << widget->objectName();
+	QWidget *next = m_stack.size() ? m_stack.top() : 0;
+	qDebug() << "Next Widget is:" << next->objectName();
+	if (next)
+		next->move(widget->pos());
 
-		widget->hide();
-		if (m_ownership.value(widget))
-			widget->deleteLater();
-		m_ownership.remove(widget);
-	}
+	present(next);
+
+	widget->hide();
+	if (m_ownership.value(widget))
+		widget->deleteLater();
+	m_ownership.remove(widget);
 }
 
 void RootController::dismissAllWidgets()
 {
 	if (!m_dismissable)
 		return;
-	while (m_stack.size() > 2) //Remaining: HomeWidget and NetworkSettingsWidget
+	while (m_stack.size() > 1) // Remaining: HomeWidget
 		dismissWidget();
 	printStack();
 	present(m_stack.at(0));

--- a/src/SensorModel.cpp
+++ b/src/SensorModel.cpp
@@ -17,62 +17,73 @@ class SensorNameItem : public QStandardItem
 {
 public:
 	SensorNameItem(SensorModel::SensorType type, const int port = -1)
-		: m_type(type)
-    		, m_port(port)
-		, m_typeName(typeName(type))
-		, m_optionName(optionName(type))
+		: m_type(type), m_port(port), m_typeName(typeName(type)), m_optionName(optionName(type))
 	{
 		setText(m_typeName + (port >= 0 ? QObject::tr(" %1").arg(port) : QString()));
 	}
-	
+
 	SensorModel::SensorType sensorType() const
 	{
 		return m_type;
 	}
-  
-  int port() const
-  {
-    return m_port;
-  }
-	
-	template<typename T>
+
+	int port() const
+	{
+		return m_port;
+	}
+
+	template <typename T>
 	static SensorNameItem *cast(T *t)
 	{
 		return dynamic_cast<SensorNameItem *>(t);
 	}
-	
+
 private:
 	static QString typeName(SensorModel::SensorType type)
 	{
-		switch(type) {
-		case SensorModel::Analog: return QObject::tr("Analog Sensor");
-		case SensorModel::Digital: return QObject::tr("Digital Sensor");
-		case SensorModel::AccelX: return QObject::tr("Accelerometer X");
-		case SensorModel::AccelY: return QObject::tr("Accelerometer Y");
-		case SensorModel::AccelZ: return QObject::tr("Accelerometer Z");
+		switch (type)
+		{
+		case SensorModel::Analog:
+			return QObject::tr("Analog Sensor");
+		case SensorModel::Digital:
+			return QObject::tr("Digital Sensor");
+		case SensorModel::AccelX:
+			return QObject::tr("Accelerometer X");
+		case SensorModel::AccelY:
+			return QObject::tr("Accelerometer Y");
+		case SensorModel::AccelZ:
+			return QObject::tr("Accelerometer Z");
 #ifdef WOMBAT
-		case SensorModel::GyroX: return QObject::tr("Gyrometer X");
-		case SensorModel::GyroY: return QObject::tr("Gyrometer Y");
-		case SensorModel::GyroZ: return QObject::tr("Gyrometer Z");
-		case SensorModel::MagnetoX: return QObject::tr("Magnetometer X");
-		case SensorModel::MagnetoY: return QObject::tr("Magnetometer Y");
-		case SensorModel::MagnetoZ: return QObject::tr("Magnetometer Z");
-                //case SensorModel::ButtonLeft: return QObject::tr("Button - Left");
-                case SensorModel::Button: return QObject::tr("Button");
+		case SensorModel::GyroX:
+			return QObject::tr("Gyrometer X");
+		case SensorModel::GyroY:
+			return QObject::tr("Gyrometer Y");
+		case SensorModel::GyroZ:
+			return QObject::tr("Gyrometer Z");
+		case SensorModel::MagnetoX:
+			return QObject::tr("Magnetometer X");
+		case SensorModel::MagnetoY:
+			return QObject::tr("Magnetometer Y");
+		case SensorModel::MagnetoZ:
+			return QObject::tr("Magnetometer Z");
+		// case SensorModel::ButtonLeft: return QObject::tr("Button - Left");
+		case SensorModel::Button:
+			return QObject::tr("Button");
 
 #endif
-		default: break;
+		default:
+			break;
 		}
 		return QObject::tr("Unknown Sensor");
 	}
-	
+
 	static QString optionName(SensorModel::SensorType type)
 	{
 		return QString();
 	}
-	
+
 	SensorModel::SensorType m_type;
-  	int m_port;
+	int m_port;
 	QString m_typeName;
 	QString m_optionName;
 };
@@ -81,41 +92,41 @@ class Updateable
 {
 public:
 	virtual void update() = 0;
-	
-	template<typename T>
+
+	template <typename T>
 	static Updateable *cast(T *t)
 	{
 		return dynamic_cast<Updateable *>(t);
 	}
 };
 
-template<typename T>
+template <typename T>
 class SensorValueItem : public QStandardItem, public Updateable
 {
 public:
 	SensorValueItem(Sensor<T> *const sensor, const bool owns)
-		: m_sensor(sensor)
-		, m_owns(owns)
+		: m_sensor(sensor), m_owns(owns)
 	{
 	}
-	
+
 	~SensorValueItem()
 	{
-		if(!m_owns) return;
+		if (!m_owns)
+			return;
 		delete m_sensor;
 	}
-	
+
 	virtual void update()
 	{
 		setText(QString("%1").arg(m_sensor->value()));
 	}
-	
-	template<typename L>
+
+	template <typename L>
 	static SensorValueItem *cast(L *t)
 	{
 		return dynamic_cast<SensorValueItem *>(t);
 	}
-	
+
 private:
 	Sensor<T> *const m_sensor;
 	bool m_owns;
@@ -152,9 +163,11 @@ SensorModel::SensorType SensorModel::type(const QModelIndex &index) const
 
 void SensorModel::update()
 {
-	for(int i = 0; i < rowCount(); ++i) {
+	for (int i = 0; i < rowCount(); ++i)
+	{
 		Updateable *updateable = Updateable::cast(item(i, 1));
-		if(!updateable) continue;
+		if (!updateable)
+			continue;
 		updateable->update();
 	}
 }
@@ -162,11 +175,15 @@ void SensorModel::update()
 void SensorModel::populate()
 {
 #ifdef WOMBAT
-	for(unsigned int i = 0; i < 6; ++i) populateAnalog(i);
-	for(unsigned int i = 0; i < 10; ++i) populateDigital(i);
+	for (unsigned int i = 0; i < 6; ++i)
+		populateAnalog(i);
+	for (unsigned int i = 0; i < 10; ++i)
+		populateDigital(i);
 #else
-	for(unsigned int i = 0; i < 8; ++i) populateAnalog(i);
-	for(unsigned int i = 0; i < 16; ++i) populateDigital(i);
+	for (unsigned int i = 0; i < 8; ++i)
+		populateAnalog(i);
+	for (unsigned int i = 0; i < 16; ++i)
+		populateDigital(i);
 #endif
 	populateAccel();
 #ifdef WOMBAT
@@ -179,76 +196,68 @@ void SensorModel::populate()
 void SensorModel::populateAnalog(const unsigned char port)
 {
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::Analog, port)
-		<< new SensorValueItem<unsigned short>(new kipr::analog::Analog(port), true));
-
+			  << new SensorNameItem(SensorModel::Analog, port)
+			  << new SensorValueItem<unsigned short>(new kipr::analog::Analog(port), true));
 }
 
 void SensorModel::populateDigital(const unsigned char port)
 {
 #ifdef WOMBAT
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::Digital, port)
-		<< new SensorValueItem<bool>(new kipr::digital::Digital(port), true));
+			  << new SensorNameItem(SensorModel::Digital, port)
+			  << new SensorValueItem<bool>(new kipr::digital::Digital(port), true));
 #else
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::Digital, port)
-		<< new SensorValueItem<bool>(new logic::Not(new kipr::digital::Digital(port), true), true));
+			  << new SensorNameItem(SensorModel::Digital, port)
+			  << new SensorValueItem<bool>(new logic::Not(new kipr::digital::Digital(port), true), true));
 #endif
 }
 
 void SensorModel::populateAccel()
 {
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::AccelX)
-		<< new SensorValueItem<short>(new kipr::accel::AccelX(), true));
+			  << new SensorNameItem(SensorModel::AccelX)
+			  << new SensorValueItem<short>(new kipr::accel::AccelX(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::AccelY)
-		<< new SensorValueItem<short>(new kipr::accel::AccelY(), true));
+			  << new SensorNameItem(SensorModel::AccelY)
+			  << new SensorValueItem<short>(new kipr::accel::AccelY(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::AccelZ)
-		<< new SensorValueItem<short>(new kipr::accel::AccelZ(), true));
+			  << new SensorNameItem(SensorModel::AccelZ)
+			  << new SensorValueItem<short>(new kipr::accel::AccelZ(), true));
 }
 
 #ifdef WOMBAT
 void SensorModel::populateGyro()
 {
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::GyroX)
-		<< new SensorValueItem<short>(new ::GyroX(), true));
+			  << new SensorNameItem(SensorModel::GyroX)
+			  << new SensorValueItem<short>(new kipr::gyro::GyroX(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::GyroY)
-		<< new SensorValueItem<short>(new ::GyroY(), true));
+			  << new SensorNameItem(SensorModel::GyroY)
+			  << new SensorValueItem<short>(new kipr::gyro::GyroY(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::GyroZ)
-		<< new SensorValueItem<short>(new ::GyroZ(), true));
+			  << new SensorNameItem(SensorModel::GyroZ)
+			  << new SensorValueItem<short>(new kipr::gyro::GyroZ(), true));
 }
 
 void SensorModel::populateMagneto()
 {
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::MagnetoX)
-		<< new SensorValueItem<short>(new ::MagnetoX(), true));
+			  << new SensorNameItem(SensorModel::MagnetoX)
+			  << new SensorValueItem<short>(new kipr::magneto::MagnetoX(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::MagnetoY)
-		<< new SensorValueItem<short>(new ::MagnetoY(), true));
+			  << new SensorNameItem(SensorModel::MagnetoY)
+			  << new SensorValueItem<short>(new kipr::magneto::MagnetoY(), true));
 	appendRow(QList<QStandardItem *>()
-		<< new SensorNameItem(SensorModel::MagnetoZ)
-		<< new SensorValueItem<short>(new ::MagnetoZ(), true));
+			  << new SensorNameItem(SensorModel::MagnetoZ)
+			  << new SensorValueItem<short>(new kipr::magneto::MagnetoZ(), true));
 }
 
 void SensorModel::populateButtons()
 {
-//        appendRow(QList<QStandardItem *>()
- //               << new SensorNameItem(SensorModel::ButtonLeft)
- //               << new SensorValueItem<bool>(new ::IdButton(Button::Type::Left, ""), true));
-//		<< new SensorValueItem<bool>(&(::Button::Left), true));
-        appendRow(QList<QStandardItem *>()
-                << new SensorNameItem(SensorModel::Button)
-//		<< new SensorValueItem<bool>(&(::Button::Right), true));
-                << new SensorValueItem<bool>(new ::IdButton(Button::Type::Right, ""), true));
-
-
+	appendRow(QList<QStandardItem *>()
+			  << new SensorNameItem(SensorModel::Button)
+			  << new SensorValueItem<bool>(&kipr::button::Right, false)); // can't instantiate new buttons since Id is private, so thus this doesn't belong to it
 }
 
 #endif

--- a/src/SensorModel.cpp
+++ b/src/SensorModel.cpp
@@ -50,7 +50,7 @@ private:
 		case SensorModel::AccelX: return QObject::tr("Accelerometer X");
 		case SensorModel::AccelY: return QObject::tr("Accelerometer Y");
 		case SensorModel::AccelZ: return QObject::tr("Accelerometer Z");
-#ifdef WALLABY
+#ifdef WOMBAT
 		case SensorModel::GyroX: return QObject::tr("Gyrometer X");
 		case SensorModel::GyroY: return QObject::tr("Gyrometer Y");
 		case SensorModel::GyroZ: return QObject::tr("Gyrometer Z");
@@ -161,7 +161,7 @@ void SensorModel::update()
 
 void SensorModel::populate()
 {
-#ifdef WALLABY
+#ifdef WOMBAT
 	for(unsigned int i = 0; i < 6; ++i) populateAnalog(i);
 	for(unsigned int i = 0; i < 10; ++i) populateDigital(i);
 #else
@@ -169,7 +169,7 @@ void SensorModel::populate()
 	for(unsigned int i = 0; i < 16; ++i) populateDigital(i);
 #endif
 	populateAccel();
-#ifdef WALLABY
+#ifdef WOMBAT
 	populateGyro();
 	populateMagneto();
 	populateButtons();
@@ -186,7 +186,7 @@ void SensorModel::populateAnalog(const unsigned char port)
 
 void SensorModel::populateDigital(const unsigned char port)
 {
-#ifdef WALLABY
+#ifdef WOMBAT
 	appendRow(QList<QStandardItem *>()
 		<< new SensorNameItem(SensorModel::Digital, port)
 		<< new SensorValueItem<bool>(new kipr::digital::Digital(port), true));
@@ -210,7 +210,7 @@ void SensorModel::populateAccel()
 		<< new SensorValueItem<short>(new kipr::accel::AccelZ(), true));
 }
 
-#ifdef WALLABY
+#ifdef WOMBAT
 void SensorModel::populateGyro()
 {
 	appendRow(QList<QStandardItem *>()

--- a/src/SensorsWidget.cpp
+++ b/src/SensorsWidget.cpp
@@ -17,18 +17,17 @@
 
 SensorsWidget::SensorsWidget(Device *device, QWidget *parent)
 	: QWidget(parent),
-	m_menuBar(new MenuBar(this)),
-	ui(new Ui::SensorsWidget)
+	  m_menuBar(new MenuBar(this)),
+	  ui(new Ui::SensorsWidget)
 {
 	ui->setupUi(this);
 	m_menuBar->addHomeAndBackButtons();
 	m_menuBar->setTitle(tr("Sensors"));
 	layout()->setMenuBar(m_menuBar);
-  
-	
+
 	m_plots[0] = ui->plot->addPlot(QColor(200, 0, 0));
 	m_plots[1] = ui->plot->addPlot(QColor(0, 0, 200));
-	
+
 	QTimer *updateTimer = new QTimer(this);
 	connect(updateTimer, SIGNAL(timeout()), SLOT(update()));
 	updateTimer->start(10);
@@ -43,7 +42,7 @@ void SensorsWidget::update()
 {
 	ui->val1->setText(QString::number(rawValue(ui->plot1->currentIndex())));
 	ui->val2->setText(QString::number(rawValue(ui->plot2->currentIndex())));
-	
+
 	ui->plot->push(m_plots[0], value(ui->plot1->currentIndex()));
 	ui->plot->push(m_plots[1], value(ui->plot2->currentIndex()));
 	ui->plot->inc();
@@ -52,30 +51,49 @@ void SensorsWidget::update()
 double SensorsWidget::rawValue(const int &i) const
 {
 	double val = 0;
-#ifdef WALLABY
-	if(i < 6) val = analog(i);
-	else if(i < 10) val = get_motor_position_counter(i - 6);
-	else if(i == 10) val = accel_x();
-	else if(i == 11) val = accel_y();
-	else if(i == 12) val = accel_z();
-	else if(i == 13) val = gyro_x();
-	else if(i == 14) val = gyro_y();
-	else if(i == 15) val = gyro_z();
-	else if(i == 16) val = magneto_x();
-	else if(i == 17) val = magneto_y();
-	else if(i == 18) val = magneto_z();
-	else if(i == 19) val = left_button();
-        else if(i == 20){
-            if(right_button() == true) val = false;
-            else if (right_button() == false) val= true;
-
-        }
+#ifdef WOMBAT
+	if (i < 6)
+		val = analog(i);
+	else if (i < 10)
+		val = get_motor_position_counter(i - 6);
+	else if (i == 10)
+		val = accel_x();
+	else if (i == 11)
+		val = accel_y();
+	else if (i == 12)
+		val = accel_z();
+	else if (i == 13)
+		val = gyro_x();
+	else if (i == 14)
+		val = gyro_y();
+	else if (i == 15)
+		val = gyro_z();
+	else if (i == 16)
+		val = magneto_x();
+	else if (i == 17)
+		val = magneto_y();
+	else if (i == 18)
+		val = magneto_z();
+	else if (i == 19)
+		val = left_button();
+	else if (i == 20)
+	{
+		if (right_button() == true)
+			val = false;
+		else if (right_button() == false)
+			val = true;
+	}
 #else
-	if(i < 8) val = analog(i);
-	else if(i < 12) val = get_motor_position_counter(i - 8);
-	else if(i == 12) val = accel_x();
-	else if(i == 13) val = accel_y();
-	else if(i == 14) val = accel_z();
+	if (i < 8)
+		val = analog(i);
+	else if (i < 12)
+		val = get_motor_position_counter(i - 8);
+	else if (i == 12)
+		val = accel_x();
+	else if (i == 13)
+		val = accel_y();
+	else if (i == 14)
+		val = accel_z();
 #endif
 	return val;
 }
@@ -83,17 +101,25 @@ double SensorsWidget::rawValue(const int &i) const
 double SensorsWidget::value(const int &i) const
 {
 	double val = rawValue(i);
-	
-#ifdef WALLABY
-	if(i < 6) val = val / 2048.0 - 1.0;
-	else if(i < 10) val = val / 32768.0;
-	else if(i < 19) val = val / 2046.0;
-	else val = 0.0;
+
+#ifdef WOMBAT
+	if (i < 6)
+		val = val / 2048.0 - 1.0;
+	else if (i < 10)
+		val = val / 32768.0;
+	else if (i < 19)
+		val = val / 2046.0;
+	else
+		val = 0.0;
 #else
-	if(i < 8) val = val / 512.0 - 1.0;
-	else if(i < 12) val = val / 32768.0;
-	else if(i < 15) val = val / 512.0;
-	else val = 0.0;
+	if (i < 8)
+		val = val / 512.0 - 1.0;
+	else if (i < 12)
+		val = val / 32768.0;
+	else if (i < 15)
+		val = val / 512.0;
+	else
+		val = 0.0;
 #endif
 
 	return val;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   CursorManager::ref().setDevice(&device);
 #ifdef QT_DBUS_LIB
   KovanSerialBridge::ref().init(&device);
-  NetworkManager::ref();
+  NetworkManager::ref().init(&device);
 #endif
 
   SettingsProvider *const settings = device.settingsProvider();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,48 +20,46 @@
 #include <QSettings>
 #include <QTranslator>
 
-int main(int argc, char* argv[])
-{ 
-	QApplication::setStyle(new MechanicalStyle);
+int main(int argc, char *argv[])
+{
+  QApplication::setStyle(new MechanicalStyle);
   QApplication::setOrganizationName("KIPR");
   QApplication::setApplicationName("botui");
-  
-	QApplication app(argc, argv);
-  
+
+  QApplication app(argc, argv);
+
   QTranslator translator;
   const QString trFile = "botui_" + QSettings().value("locale", "en").toString().left(2);
   qDebug() << "Trying to use translation file " << trFile;
-  if(trFile != "botui_en" && translator.load(trFile, "/etc/botui/locale/"))
+  if (trFile != "botui_en" && translator.load(trFile, "/etc/botui/locale/"))
   {
     qDebug() << "Successfully loaded translation file " << trFile;
     app.installTranslator(&translator);
   }
-	
-	QDir::setCurrent(QApplication::applicationDirPath());
-	qmlRegisterType<BusyIndicator>("ZapBsComponents", 1, 0, "BusyIndicator");
-	
-	QFontDatabase::addApplicationFont(":/fonts/DejaVuSans-ExtraLight.ttf");
-	QFontDatabase::addApplicationFont(":/fonts/DejaVuSans.ttf");
-	QFontDatabase::addApplicationFont(":/fonts/DejaVuSansMono.ttf");
-	
-	srand(time(NULL));
-	
-	Wombat::Device device;
-	CursorManager::ref().setDevice(&device);
+
+  QDir::setCurrent(QApplication::applicationDirPath());
+  qmlRegisterType<BusyIndicator>("ZapBsComponents", 1, 0, "BusyIndicator");
+
+  QFontDatabase::addApplicationFont(":/fonts/DejaVuSans-ExtraLight.ttf");
+  QFontDatabase::addApplicationFont(":/fonts/DejaVuSans.ttf");
+  QFontDatabase::addApplicationFont(":/fonts/DejaVuSansMono.ttf");
+
+  srand(time(NULL));
+
+  Wombat::Device device;
+  CursorManager::ref().setDevice(&device);
 #ifdef QT_DBUS_LIB
   KovanSerialBridge::ref().init(&device);
   NetworkManager::ref();
 #endif
-  
+
   SettingsProvider *const settings = device.settingsProvider();
   const bool fullscreen = settings && settings->value("fullscreen", true).toBool();
   RootController::ref().setFullscreen(fullscreen);
-	//GuiSettingsWidget::updateStyle(&device);
-	
-	RootController::ref().presentWidget(new HomeWidget(&device));
-  NetworkSettingsWidget *networkWidget = new NetworkSettingsWidget(&device);
-  
-  RootController::ref().addNetworkSettingsStack(networkWidget);
+  // GuiSettingsWidget::updateStyle(&device);
+
+  RootController::ref().presentWidget(new HomeWidget(&device));
+
   RootController::ref().printStack();
-	return app.exec();
+  return app.exec();
 }


### PR DESCRIPTION
* Change defines to `#ifdef WOMBAT` instead of `#ifdef WALLABY` to match the new CMakeLists.txt
* Fix compile errors within the sensors widget when compiling for wombat
* Make network settings persistent (stays in "AP Mode" or "Client Mode" or "Wifi OFF")
* Fill in the password section (before, it was left blank, but now it shows the password of the wifi as intended)
* only have 1 window open at a time (before, networkmanagerwidget had to always be open, now it doesn't so it isn't always open)

Note: in `NetworkManager.cpp`, you may have to change the wifi device to match the wifi device on your computer